### PR TITLE
#6: Rename `sentryConfig` to `sentry`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+* [#6: Rename `sentryConfig` to `sentry`.](https://github.com/haensl/iso-log/issues/6)
+* Update dependencies.
+
 ## 1.0.1
 * [#4: Fix bundle.](https://github.com/haensl/iso-log/issues/4)
 * Update dependencies.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ iso-log offers the same API `console` does plus an `init()` function:
 
 `warn(...args)`: Log at warning log level.
 
-`init({ environment, name, sentryConfig })`: Initialize the log. (See [Configuration](#config)).
+`init({ environment, name, sentry })`: Initialize the log. (See [Configuration](#config)).
 
 ## Configuration <a name="config"></a>
 
@@ -114,8 +114,8 @@ log.init({
   // Provide Sentry configuration.
   // Object.
   // Optional.
-  // This config object is handed to Sentry: `Sentry.init(sentryConfig)`
-  sentryConfig: {
+  // This config object is handed to Sentry: `Sentry.init(sentry)`
+  sentry: {
     dsn: 'your sentry DSN here'
   }
 });
@@ -151,7 +151,7 @@ iso-log determines the runtime platform by presence/absence of a global `window`
 
 ### Report errors and warnings to [Sentry](https://sentry.io)
 
-You can provide a [`sentryConfig`](https://docs.sentry.io/platforms/node/configuration/) object to the initialization call. If you do, all `Error` objects handed to `log.error` and `log.warn` will be forwarded to Sentry.
+You can provide a [`sentry` configuration object](https://docs.sentry.io/platforms/node/configuration/) to the initialization call. If you do, all `Error` objects handed to `log.error` and `log.warn` will be forwarded to Sentry.
 
 #### Enriching errors reported to Sentry
 
@@ -250,5 +250,7 @@ You can attach additional information about the error by setting theses props on
       }
     };
     ```
+
+    See e.g. [`koa-error-middleware`](https://github.com/haensl/koa-error-middleware).
 
 ## [Changelog](CHANGELOG.md)

--- a/index.js
+++ b/index.js
@@ -81,13 +81,13 @@ const info = (...args) => {
 const init = ({
   environment,
   name,
-  sentryConfig
+  sentry
 }) => {
-  if (sentryConfig) {
+  if (sentry) {
     if (platform.hasWindow) {
-      _sentry = SentryBrowser.init(sentryConfig);
+      _sentry = SentryBrowser.init(sentry);
     } else {
-      _sentry = SentryNode.init(sentryConfig);
+      _sentry = SentryNode.init(sentry);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@haensl/iso-log",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@haensl/iso-log",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@haensl/environments": "^1.0.1",
@@ -1212,13 +1212,13 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.55.0.tgz",
-      "integrity": "sha512-Bm82Z2tHcz4BF8CQDfYT5LeZPpuePWNHcxTSknJImPpPlQnol++2WQtloZZOs5FxllXL08UjN3LphRKmiEQsVQ==",
+      "version": "7.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.55.2.tgz",
+      "integrity": "sha512-yBW+R7NfwLrOjpwOJHoOSvGDDoM3ZKod5OKXi7Gd5tYqVm1mCaL0n2/wlNMcGTbPbulLBtgzjoTU1bPJAGhmYw==",
       "dependencies": {
-        "@sentry/core": "7.55.0",
-        "@sentry/types": "7.55.0",
-        "@sentry/utils": "7.55.0",
+        "@sentry/core": "7.55.2",
+        "@sentry/types": "7.55.2",
+        "@sentry/utils": "7.55.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1226,15 +1226,15 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.55.0.tgz",
-      "integrity": "sha512-ukwj7MBkZx0IBDL5MfNcerZp8p5M85m+AZ7LFEw2aMVFSt4HEmp1CPQYpubORMcP+oq+BHGJ6khkvNQlM4D7+g==",
+      "version": "7.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.55.2.tgz",
+      "integrity": "sha512-RgA4KOD6t8XHVLm6D2oTh9KW19g3DoQ0QsrUmAq4+giSj2AyDW67VP2V4E72mCZ9Ln9AkNhY0Eh3XuD3opiFQA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.55.0",
-        "@sentry/core": "7.55.0",
-        "@sentry/replay": "7.55.0",
-        "@sentry/types": "7.55.0",
-        "@sentry/utils": "7.55.0",
+        "@sentry-internal/tracing": "7.55.2",
+        "@sentry/core": "7.55.2",
+        "@sentry/replay": "7.55.2",
+        "@sentry/types": "7.55.2",
+        "@sentry/utils": "7.55.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1242,12 +1242,12 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.55.0.tgz",
-      "integrity": "sha512-ClOcxdAlX7aS52UQQFc7zAIoqyV24wZnDamJTNtnygETGhrjsj4sUyhelF0xecn5gyYJQ0pfT55iBTGacms8Ag==",
+      "version": "7.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.55.2.tgz",
+      "integrity": "sha512-clzQirownxqADv9+fopyMJTHzaoWedkN2+mi4ro1LxjLgROdXBFurMCC1nT+7cH/xvQ5gMIRkM/y/4gRtKy2Ew==",
       "dependencies": {
-        "@sentry/types": "7.55.0",
-        "@sentry/utils": "7.55.0",
+        "@sentry/types": "7.55.2",
+        "@sentry/utils": "7.55.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1255,14 +1255,14 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.55.0.tgz",
-      "integrity": "sha512-X7v1LoZu6mlZAg7eDz+gU4V0QdfcKcZjI/4bxl6E9yKX6VH5ORuNaNujWXMfzu7Yvu8Dtp+JZ0ZDa+9nEmXbZQ==",
+      "version": "7.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.55.2.tgz",
+      "integrity": "sha512-43lGfMFFUD38Xerc4DqIuQkEOETHCh31JHUTI6r/gXdzmcKpWRscgH4nAcAUoCu+Myrv0fVXsOa12FM4DPfr8A==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.55.0",
-        "@sentry/core": "7.55.0",
-        "@sentry/types": "7.55.0",
-        "@sentry/utils": "7.55.0",
+        "@sentry-internal/tracing": "7.55.2",
+        "@sentry/core": "7.55.2",
+        "@sentry/types": "7.55.2",
+        "@sentry/utils": "7.55.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -1273,32 +1273,32 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.55.0.tgz",
-      "integrity": "sha512-SRWYNgSTGjUBONRJk939MJTynk6fxK524J5Sa/ABHHo+Gow1O8F1q9GY4OIIGkh0Giz8rO6vePWBwuDE6F7B2Q==",
+      "version": "7.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.55.2.tgz",
+      "integrity": "sha512-G9iAcI9bvy5X8fvdz0QxF3LJ8oGB0Vxt0iOPdRZYhjIcPbNpE3NaeT6xZlNX1pCcHLroE6BMRF/6TTalcl5Erw==",
       "dependencies": {
-        "@sentry/core": "7.55.0",
-        "@sentry/types": "7.55.0",
-        "@sentry/utils": "7.55.0"
+        "@sentry/core": "7.55.2",
+        "@sentry/types": "7.55.2",
+        "@sentry/utils": "7.55.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.55.0.tgz",
-      "integrity": "sha512-e8VLiR0NIYd1Y5SlATp3eSARTYmbpNEYsX2b3a1E0NDZj+G5eOqef7k6ab6Y30LUrqrqmkDE0VJqTtnI3pMzzg==",
+      "version": "7.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.55.2.tgz",
+      "integrity": "sha512-mAtkA8wvUDrLjAAmy9tjn+NiXcxVz/ltbslTKaIW6JNgVRz5kMt1Ny8RJsgqaZqa4LFP8q+IvWw4Vd91kb57rA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.55.0.tgz",
-      "integrity": "sha512-18YU0fLhlr/e7lUyMkh/BEE05N8DG9lzWToz6c9DOYw6pTyt2EXZrxho+BcYufd7IayU0Twb0sp8EX/wfggYxA==",
+      "version": "7.55.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.55.2.tgz",
+      "integrity": "sha512-Yv9XtbOESdN7bkK2AMrKsmKMF5OOVv5v5hVcOqXtSTw1t2oMAtRjXXqGpUo+TkdTOjeoX6dr19ozVFHaGvqHkw==",
       "dependencies": {
-        "@sentry/types": "7.55.0",
+        "@sentry/types": "7.55.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1755,9 +1755,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001502",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
-      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
+      "version": "1.0.30001503",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
+      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
       "dev": true,
       "funding": [
         {
@@ -1980,9 +1980,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.429",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.429.tgz",
-      "integrity": "sha512-COua8RvN548KwPFzKMrTjFbmDsQRgdi0zSAhmo70TwC1tfLOSqq8p09n+GkdF5buvzE/NEYn1dP3itbfhun9gg==",
+      "version": "1.4.430",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.430.tgz",
+      "integrity": "sha512-FytjTbGwz///F+ToZ5XSeXbbSaXalsVRXsz2mHityI5gfxft7ieW3HqFLkU5V1aIrY42aflICqbmFoDxW10etg==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haensl/iso-log",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Isomorphic logger with Bunyan and Sentry support.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 2.0.0
* [#6: Rename `sentryConfig` to `sentry`.](https://github.com/haensl/iso-log/issues/6)
* Update dependencies.

Closes #6