### PR TITLE
#8: Fix side-effect in Sentry configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* [#8: Fix side effect in Sentry configuration.](https://github.com/haensl/iso-log/issues/8)
+
 ## 2.0.0
 * [#6: Rename `sentryConfig` to `sentry`.](https://github.com/haensl/iso-log/issues/6)
 * Update dependencies.

--- a/index.js
+++ b/index.js
@@ -85,9 +85,9 @@ const init = ({
 }) => {
   if (sentry) {
     if (platform.hasWindow) {
-      _sentry = SentryBrowser.init(sentry);
+      _sentry = SentryBrowser.init({ ...sentry });
     } else {
-      _sentry = SentryNode.init(sentry);
+      _sentry = SentryNode.init({ ...sentry });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haensl/iso-log",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Isomorphic logger with Bunyan and Sentry support.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 2.0.1
* [#8: Fix side effect in Sentry configuration.](https://github.com/haensl/iso-log/issues/8)

Closes #8